### PR TITLE
Adding the default parameters view for CoordinatorParameterValue to avoi...

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/coordinator/model/CoordinatorParameterValue/value.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/coordinator/model/CoordinatorParameterValue/value.jelly
@@ -1,0 +1,11 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+	xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+	<j:if test="${it.value.class.name != 'org.jenkinsci.plugins.coordinator.model.TreeNode' }">
+		<f:entry title="${it.name}" description="${it.description}">
+	        <div tooltip="Regular expression = ${it.regex}">
+	            <f:textbox name="value" value="${it.value}" readonly="true" />
+	        </div>
+		</f:entry>
+    </j:if>
+</j:jelly>


### PR DESCRIPTION
...d break jenkins.

On coordinator job, when you browse on job > build > Console output we have the link to
"Parameters" view. When we try this link, jenkins breaks with the message:
/hudson/model/ParametersAction/index.jelly:41:27: <st:include> No page found 'value.jelly' for class org.jenkinsci.plugins.coordinator.model.CoordinatorParameterValue

To avoid this problem, this commit implements the default Parameter's view, removing the TreeNode objects.