### PR TITLE
Fix NullPointerException for scheduled execution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorBuild.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorBuild.java
@@ -54,7 +54,17 @@ public class CoordinatorBuild extends Build<CoordinatorProject, CoordinatorBuild
 	
 	private TreeNode originalExecutionPlan;
 	
+	private TreeNode defaultExecutionPlan;
+	
 	private transient Map<String, Integer> tableRowIndexMap;
+	
+	public CoordinatorBuild(CoordinatorProject project) throws IOException {
+		super(project);
+	}
+
+	public CoordinatorBuild(CoordinatorProject project, File buildDir) throws IOException {
+        super(project, buildDir);
+    }
 	
 	/*package*/ TreeNode getOriginalExecutionPlan() {
 		return originalExecutionPlan;
@@ -63,15 +73,16 @@ public class CoordinatorBuild extends Build<CoordinatorProject, CoordinatorBuild
 	public void setOriginalExecutionPlan(TreeNode originalExecutionPlan) {
 		this.originalExecutionPlan = originalExecutionPlan;
 	}
-
-	public CoordinatorBuild(CoordinatorProject project) throws IOException {
-		super(project);
+	
+	public TreeNode getDefaultExecutionPlan() {
+		return defaultExecutionPlan;
 	}
 
-	public CoordinatorBuild(CoordinatorProject project, File buildDir) throws IOException {
-        super(project, buildDir);
-    }
+	public void setDefaultExecutionPlan(TreeNode defaultExecutionPlan) {
+		this.defaultExecutionPlan = defaultExecutionPlan;
+	}
 
+	
 	public void addOldActions(List<? extends Action> oldActions) {
 		this.oldActions.add(oldActions);
 	}

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorProject.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorProject.java
@@ -51,10 +51,12 @@ public class CoordinatorProject extends
 	
 	private static final Logger LOGGER = Logger.getLogger(CoordinatorProject.class.getName());
 	
+	private TreeNode defaultExecutionPlan;
+	
 	public CoordinatorProject(ItemGroup<?> parent, String name) {
 		super(parent, name);
 	}
-
+	
 	@Override
 	public void onLoad(ItemGroup<? extends Item> parent, String name) throws IOException {
 		super.onLoad(parent, name);
@@ -64,6 +66,7 @@ public class CoordinatorProject extends
 	
 	
 	protected synchronized CoordinatorBuild newBuild() throws IOException {
+		
 		if (!rebuildVersions.isEmpty()) {
 			Integer rebuildVersion = rebuildVersions.remove(0);
 			CoordinatorBuild targetBuild = super.getBuildByNumber(rebuildVersion);
@@ -83,13 +86,21 @@ public class CoordinatorProject extends
 			reset(targetBuild);
 			return targetBuild;
 		} else {
-			CoordinatorBuild cb = super.newBuild();
 			TreeNode brandNewExecutionPlan = this.getCoordinatorBuilder().getExecutionPlan().clone(true);
+			this.setDefaultExecutionPlan(brandNewExecutionPlan);
+			CoordinatorBuild cb = super.newBuild();
 			cb.setOriginalExecutionPlan(brandNewExecutionPlan);
+			cb.setDefaultExecutionPlan(this.defaultExecutionPlan);
 			return cb;
 		}
 	}
 	
+	private void setDefaultExecutionPlan(TreeNode executionPlan) {
+		if (defaultExecutionPlan == null) {
+			this.defaultExecutionPlan = executionPlan;
+		}
+	}
+
 	protected void reset(CoordinatorBuild targetBuild) {
 		Object notStarted = extractNotStartEnumConstant();
 		setField(targetBuild, "state", notStarted);

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
@@ -83,7 +83,6 @@ public class PerformExecutor {
 		executorPool = Executors.newFixedThreadPool(poolSize);
 	}
 	
-	
 	public boolean execute(){
 		prepareExecutionPlan();
 		kickOffBuild(this.coordinatorBuild.getOriginalExecutionPlan());
@@ -115,12 +114,21 @@ public class PerformExecutor {
 	private void prepareExecutionPlan() {
 		CoordinatorParameterValue parameter = (CoordinatorParameterValue)this.coordinatorBuild.getAction(ParametersAction.class)
 				.getParameter(CoordinatorParameterValue.PARAM_KEY);
-		TreeNode rootNode = parameter.getValue();
+
+		TreeNode rootNode = null;
+		if (parameter == null) {
+			// use default execution plan when the job is scheduled
+			rootNode = this.coordinatorBuild.getDefaultExecutionPlan();
+		} else {
+			rootNode = parameter.getValue();
+		}
+
 		TreeNode.mergeState(this.coordinatorBuild.getOriginalExecutionPlan(), rootNode);
 		parameterMap = new HashMap<String, TreeNode>();
 		for(TreeNode node: rootNode.getFlatNodes(false)){
 			parameterMap.put(node.getId(), node);
 		}
+		
 	}
 	
 	

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/TreeNode.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/TreeNode.java
@@ -176,7 +176,7 @@ public class TreeNode {
 		clone.id = this.id;
 		clone.text = this.text;
 		clone.type = this.type;
-		clone.state = this.state;
+		clone.state = this.state.clone();
 		clone.parent = this.parent;
 		clone.buildNumber = this.buildNumber;
 		if(deep){
@@ -203,6 +203,16 @@ public class TreeNode {
 	    //public String type; // it's weird that type in state doesnot change as ui changes
 	    
 	    public State(){}
+	    
+		public State clone() {
+			State clone = new State();
+			clone.checked = this.checked;
+			clone.disabled = this.disabled;
+			clone.opened = this.opened;
+			clone.selected = this.opened;
+			clone.undetermined = this.undetermined;
+			return clone;
+		}
 	}
 	
 	public static TreeNode fromString(String jsonStr){

--- a/src/main/resources/org/jenkinsci/plugins/coordinator/model/CoordinatorBuilder/help-executionPlan.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/coordinator/model/CoordinatorBuilder/help-executionPlan.jelly
@@ -7,5 +7,5 @@
 	xmlns:t="/lib/hudson" 
 	xmlns:f="/lib/form"
 	xmlns:p="/lib/hudson/project">
-	hello world
+	Checked jobs will be used as default on scheduled execution.
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/coordinator/model/CoordinatorBuilder/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/coordinator/model/CoordinatorBuilder/help.html
@@ -7,5 +7,5 @@
 	xmlns:t="/lib/hudson" 
 	xmlns:f="/lib/form"
 	xmlns:p="/lib/hudson/project">
-	hello world
+	Add/Remove node, Add/Remove jobs, rename, check, switch on serial or parallel execution and have fun!
 </j:jelly>


### PR DESCRIPTION
When you configure scheduled execution, on build perform method you take a NullPointerException.
The cause was on PerformExecutor#prepareExecutionPlan trying to call "parameter.getValue();", but there wasn't a value for CoordinatorParameterValue.*PARAM_KEY*.
To fix this problem, I implemented the defaultExecutionPlan, then everytime that someone schedule a execution of a coordinator job, it use the default check.

stack trace:
```
Started by timer
Building in workspace /var/lib/jenkins/workspace/coordinator
FATAL: null
java.lang.NullPointerException
	at org.jenkinsci.plugins.coordinator.model.PerformExecutor.prepareExecutionPlan(PerformExecutor.java:118)
	at org.jenkinsci.plugins.coordinator.model.PerformExecutor.execute(PerformExecutor.java:88)
	at org.jenkinsci.plugins.coordinator.model.CoordinatorBuilder.perform(CoordinatorBuilder.java:57)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:804)
	at hudson.model.Build$BuildExecution.build(Build.java:199)
	at hudson.model.Build$BuildExecution.doRun(Build.java:160)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:585)
	at hudson.model.Run.execute(Run.java:1676)
	at hudson.model.Build.run(Build.java:113)
	at hudson.model.ResourceController.execute(ResourceController.java:88)
	at hudson.model.Executor.run(Executor.java:231)
```