### PR TITLE
Integrating the Folder Plugin. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>1.596.1</version>
+		<version>1.609.1</version>
 		<!-- which version of Jenkins is this plugin built against? -->
 	</parent>
 
@@ -54,6 +54,11 @@
 	</pluginRepositories>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>cloudbees-folder</artifactId>
+			<version>5.13</version>
+		</dependency>
 		<dependency>
 			<groupId>cglib</groupId>
 			<artifactId>cglib-nodep</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
@@ -264,7 +264,6 @@ public class PerformExecutor {
 		synchronized(listener){
 			try {
 				StringBuilder sb = new StringBuilder(100);
-				// we use relative path
 				sb.append("/").append(getProject(node).getUrl());
 				listener.getLogger().print("Atomic Job: ");
 				listener.hyperlink(sb.toString(), jobName);


### PR DESCRIPTION
resolves: https://github.com/jenkinsci/coordinator-plugin/issues/34

Integrating the Folder Plugin
---
- Integrating with the Cloudbees Folder Plugin to allow triggering of projects residing in folders. 
- Bumped the required Jenkins build to 1.609.1 as per the folder plugin information (https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Folders+Plugin)
- Removed the usage of relative paths in the console Hyperlinks. Fixes issue of wrong hyperlinks being generated when nesting the coordinator plugin.

### Steps to reproduce hyperlink error:
- Create a top level folder. Name it anything
- Create a top level Free Style project. Name it anything
- Inside of the top level folder, create a Coordinator Project.
- Configure the Coordinator Project to trigger your top level free style project.
- Run the build.

### Outcome
The Build should succeed  however, when following the hyperlinks you will get a 404 page due to using relative links.