### PR TITLE
Preventing null pointer due to not building via parameterized triggers

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorBuild.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorBuild.java
@@ -160,12 +160,16 @@ public class CoordinatorBuild extends Build<CoordinatorProject, CoordinatorBuild
 			// no build or refresh or reload from disk
 			return JSONNull.getInstance();
 		}
-		CoordinatorParameterValue parameter = (CoordinatorParameterValue)this.getAction(ParametersAction.class)
-				.getParameter(CoordinatorParameterValue.PARAM_KEY);
+
 		// children under this rootNode will get its corresponding build number
 		// if it has already been built
-		TreeNode rootNode = parameter.getValue();
-		
+		TreeNode rootNode = originalExecutionPlan;
+		ParametersAction parametersAction = getAction(ParametersAction.class);
+		if (parametersAction != null) {
+			CoordinatorParameterValue parameter = (CoordinatorParameterValue) parametersAction.getParameter(CoordinatorParameterValue.PARAM_KEY);
+			rootNode = parameter.getValue();
+		}
+
 		// doesnt matter if byDepth or not for the case
 		// rootNode included
 		List<TreeNode> nodes = TreeNodeUtils.getFlatNodes(rootNode, true); 

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorBuild.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/CoordinatorBuild.java
@@ -165,7 +165,7 @@ public class CoordinatorBuild extends Build<CoordinatorProject, CoordinatorBuild
 		// if it has already been built
 		TreeNode rootNode = originalExecutionPlan;
 		ParametersAction parametersAction = getAction(ParametersAction.class);
-		if (parametersAction != null) {
+		if (parametersAction != null && parametersAction.getParameters().contains(CoordinatorParameterValue.PARAM_KEY)) {
 			CoordinatorParameterValue parameter = (CoordinatorParameterValue) parametersAction.getParameter(CoordinatorParameterValue.PARAM_KEY);
 			rootNode = parameter.getValue();
 		}

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
@@ -159,7 +159,7 @@ public class PerformExecutor {
         TreeNode requestRootNode = buildRootNode;
 
         ParametersAction parametersAction = this.coordinatorBuild.getAction(ParametersAction.class);
-        if (parametersAction != null) {
+        if (parametersAction != null && parametersAction.getParameters().contains(CoordinatorParameterValue.PARAM_KEY)) {
             CoordinatorParameterValue parameter = (CoordinatorParameterValue) parametersAction.getParameter(CoordinatorParameterValue.PARAM_KEY);
             requestRootNode = parameter.getValue();
             TreeNodeUtils.mergeState4Execution(buildRootNode, requestRootNode);

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
@@ -154,12 +154,16 @@ public class PerformExecutor {
 	 * set up failedParentNodeSet, parameterMap and parentChildrenMap
 	 */
 	private void prepareExecutionPlan() {
-		CoordinatorParameterValue parameter = (CoordinatorParameterValue)this.coordinatorBuild.getAction(ParametersAction.class)
-				.getParameter(CoordinatorParameterValue.PARAM_KEY);
-		TreeNode requestRootNode = parameter.getValue();
-		TreeNode buildRootNode = this.coordinatorBuild.getOriginalExecutionPlan();
-		TreeNodeUtils.mergeState4Execution(buildRootNode, requestRootNode);
-		
+        TreeNode buildRootNode = this.coordinatorBuild.getOriginalExecutionPlan();
+        // Use the configured execution plan above unless there's a requested change for this specific build via the "executionPlan" parameter.
+        TreeNode requestRootNode = buildRootNode;
+
+        ParametersAction parametersAction = this.coordinatorBuild.getAction(ParametersAction.class);
+        if (parametersAction != null) {
+            CoordinatorParameterValue parameter = (CoordinatorParameterValue) parametersAction.getParameter(CoordinatorParameterValue.PARAM_KEY);
+            requestRootNode = parameter.getValue();
+            TreeNodeUtils.mergeState4Execution(buildRootNode, requestRootNode);
+        }
 		// parameterMap for display build number in history page
 		parameterMap = new HashMap<String, TreeNode>();
 		for(TreeNode node: TreeNodeUtils.getFlatNodes(requestRootNode, false)){

--- a/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/coordinator/model/PerformExecutor.java
@@ -162,8 +162,9 @@ public class PerformExecutor {
         if (parametersAction != null && parametersAction.getParameters().contains(CoordinatorParameterValue.PARAM_KEY)) {
             CoordinatorParameterValue parameter = (CoordinatorParameterValue) parametersAction.getParameter(CoordinatorParameterValue.PARAM_KEY);
             requestRootNode = parameter.getValue();
-            TreeNodeUtils.mergeState4Execution(buildRootNode, requestRootNode);
         }
+
+		TreeNodeUtils.mergeState4Execution(buildRootNode, requestRootNode);
 		// parameterMap for display build number in history page
 		parameterMap = new HashMap<String, TreeNode>();
 		for(TreeNode node: TreeNodeUtils.getFlatNodes(requestRootNode, false)){


### PR DESCRIPTION
resolves: https://github.com/jenkinsci/coordinator-plugin/issues/37
resolves: https://github.com/jenkinsci/coordinator-plugin/issues/38

Problem
---
Null pointer being thrown due none parameterized build triggers.

Manually triggering a coordinator job does not throw an error as the action is providing a currently required parameter; "executionPlan". This parameter offers a chance to provide an alternative execution plan for a single build.

*Screen showing the ability to provide an alternative to the configured execution plan*
<img width="1047" alt="screen shot 2016-11-30 at 7 22 54 pm" src="https://cloud.githubusercontent.com/assets/6718377/20778325/7bf904be-b732-11e6-92c9-887d42a21977.png">

Triggers such as SCM polling do not provide the "executionPlan" parameter nor any others and therefore do not have ParametersAction actions,  thus causes the NPE.

Provided fix
---
Use the configured execution plan as the default execution plan unless the user or a parameterized plugin has provided an alternative execution plan via the "executionPlan" parameter. 

Notes
---
This PR also fixes an issue of an alert box appearing when trying to render a specific build's execution plan due to a similar issue. If a past build was not triggered in a parameterized way you would see the below.

<img width="788" alt="screen shot 2016-11-30 at 7 12 58 pm" src="https://cloud.githubusercontent.com/assets/6718377/20778582/24109580-b734-11e6-8be1-98c8eedf17a4.png">
